### PR TITLE
audio: pluggable Opus decoder, click-free buffer corrections, Wi-Fi s…

### DIFF
--- a/ChloroFrame/App/AWDLSuppressor.swift
+++ b/ChloroFrame/App/AWDLSuppressor.swift
@@ -3,7 +3,7 @@
 //  ChloroFrame
 //
 //  XPC client for the privileged ChloroFrameHelper daemon.
-//  The helper runs as root (SMJobBless) and does ioctl(SIOCSIFFLAGS) directly.
+//  The helper runs as root (SMAppService daemon) and does ioctl(SIOCSIFFLAGS) directly.
 //  Guaranteed restore: helper's connection invalidationHandler fires on app crash.
 //
 
@@ -25,52 +25,60 @@ final class AWDLSuppressor {
 
     // MARK: - Helper status
 
-    /// True if the helper binary is installed in /Library/PrivilegedHelperTools/.
-    var isHelperInstalled: Bool {
-        FileManager.default.fileExists(
-            atPath: "/Library/PrivilegedHelperTools/\(AWDLSuppressor.helperID)"
-        )
+    /// The SMAppService daemon backed by Contents/Library/LaunchDaemons/<plist>.
+    private var daemonService: SMAppService {
+        SMAppService.daemon(plistName: "\(AWDLSuppressor.helperID).plist")
     }
 
-    // MARK: - Installation (SMJobBless)
+    /// True only when the daemon is registered AND approved by the user.
+    var isHelperInstalled: Bool {
+        daemonService.status == .enabled
+    }
 
-    /// Prompts for admin credentials and installs (or updates) the privileged helper.
-    /// Call from the main thread; the auth dialog is modal.
+    // MARK: - Installation (SMAppService)
+
+    /// Registers the privileged daemon. macOS 13+ replacement for SMJobBless: the
+    /// daemon runs in-place from the app bundle (no copy to /Library/...), and the
+    /// user approves it once under System Settings > General > Login Items & Extensions.
+    /// Throws `.requiresApproval` (and opens that pane) when approval is pending.
+    /// `force: true` re-registers even when status reads `.enabled`. Needed because a
+    /// Debug rebuild re-signs the binary and silently staleness the registered job (status
+    /// stays `.enabled` but launchd won't launch it), so the daemon never answers XPC.
     @MainActor
-    func installHelper() throws {
-        var authItem  = AuthorizationItem(
-            name: kSMRightBlessPrivilegedHelper, valueLength: 0, value: nil, flags: 0
-        )
-        var authRights = AuthorizationRights(count: 1, items: &authItem)
-        var authRef: AuthorizationRef?
+    func installHelper(force: Bool = false) throws {
+        let svc = daemonService
 
-        let createErr = AuthorizationCreate(
-            &authRights, nil,
-            [.interactionAllowed, .preAuthorize, .extendRights],
-            &authRef
-        )
-        guard createErr == errAuthorizationSuccess, let ref = authRef else {
-            throw AWDLHelperError.authorizationFailed(createErr)
+        if !force, svc.status == .enabled {
+            print("[AWDLSuppressor] helper already enabled ✓")
+            return
         }
-        defer { AuthorizationFree(ref, [.destroyRights]) }
 
-        var cfErr: Unmanaged<CFError>?
-        guard SMJobBless(
-            kSMDomainSystemLaunchd,
-            AWDLSuppressor.helperID as CFString,
-            ref, &cfErr
-        ) else {
-            throw cfErr?.takeRetainedValue() ?? AWDLHelperError.blessFailed
+        // Re-registering refreshes an existing registration. We deliberately do NOT call
+        // unregister() first: if the registration was created by a different binary signature
+        // (e.g. a prior build), unregister() is denied with EPERM and wedges the item. When
+        // that happens the user must clear the background item in System Settings manually.
+        try svc.register()
+
+        switch svc.status {
+        case .enabled:
+            print("[AWDLSuppressor] helper registered ✓")
+        case .requiresApproval:
+            print("[AWDLSuppressor] helper needs approval — opening Login Items")
+            SMAppService.openSystemSettingsLoginItems()
+            throw AWDLHelperError.requiresApproval
+        default:
+            throw AWDLHelperError.registrationFailed(svc.status)
         }
-        print("[AWDLSuppressor] helper installed ✓")
     }
 
     // MARK: - Suppress / Restore
 
     func suppress() {
         guard !active else { return }
-        guard UserDefaults.standard.bool(forKey: "suppressAWDLDuringStream") else {
-            print("[AWDLSuppressor] setting disabled — skipping")
+        let wantAWDL = UserDefaults.standard.bool(forKey: "suppressAWDLDuringStream")
+        let wantLoc  = UserDefaults.standard.bool(forKey: "suppressWiFiScansDuringStream")
+        guard wantAWDL || wantLoc else {
+            print("[AWDLSuppressor] both suppressions disabled — skipping")
             return
         }
         guard isHelperInstalled else {
@@ -83,30 +91,43 @@ final class AWDLSuppressor {
             print("[AWDLSuppressor] suppress: XPC error — \(err.localizedDescription)")
         }) as? ChloroFrameHelperProtocol else { return }
 
-        proxy.setAWDL(enabled: false) { [weak self] ok in
-            print("[AWDLSuppressor] suppress → \(ok ? "awdl0 down ✓" : "ioctl failed")")
-            DispatchQueue.main.async { self?.active = ok }
+        active = true
+
+        if wantAWDL {
+            proxy.setAWDL(enabled: false) { ok in
+                print("[AWDLSuppressor] suppress → \(ok ? "awdl0 down ✓" : "ioctl failed")")
+            }
+        }
+        if wantLoc {
+            proxy.setLocationScanSuppressed(enabled: true) { ok in
+                print("[AWDLSuppressor] suppress → \(ok ? "locationd suspended ✓" : "kill failed")")
+            }
         }
     }
 
-    /// Sends the restore command and blocks until the helper confirms (or times out).
-    /// Safe to call from any thread; uses a semaphore so the caller knows restore completed.
+    /// Sends the restore commands and blocks until the helper confirms (or times out).
+    /// Resumes both awdl0 and locationd unconditionally; the helper no-ops whichever
+    /// it didn't actually suppress. Safe to call from any thread.
     func restore() {
         guard active, let conn = connection else { return }
 
-        let sem = DispatchSemaphore(value: 0)
-        let proxy = conn.remoteObjectProxyWithErrorHandler({ err in
+        let group = DispatchGroup()
+        if let proxy = conn.remoteObjectProxyWithErrorHandler({ err in
             print("[AWDLSuppressor] restore: XPC error — \(err.localizedDescription)")
-            sem.signal()
-        }) as? ChloroFrameHelperProtocol
-
-        proxy?.setAWDL(enabled: true) { ok in
-            print("[AWDLSuppressor] restore → \(ok ? "awdl0 up ✓" : "ioctl failed")")
-            sem.signal()
+        }) as? ChloroFrameHelperProtocol {
+            group.enter()
+            proxy.setAWDL(enabled: true) { ok in
+                print("[AWDLSuppressor] restore → \(ok ? "awdl0 up ✓" : "ioctl failed")")
+                group.leave()
+            }
+            group.enter()
+            proxy.setLocationScanSuppressed(enabled: false) { ok in
+                print("[AWDLSuppressor] restore → \(ok ? "locationd resumed ✓" : "kill failed")")
+                group.leave()
+            }
         }
 
-        let result = sem.wait(timeout: .now() + 3.0)
-        if result == .timedOut {
+        if group.wait(timeout: .now() + 3.0) == .timedOut {
             print("[AWDLSuppressor] restore: timed out waiting for helper reply")
         }
 
@@ -185,13 +206,15 @@ extension AWDLSuppressor {
 // MARK: - Errors
 
 enum AWDLHelperError: LocalizedError {
-    case authorizationFailed(OSStatus)
-    case blessFailed
+    case requiresApproval
+    case registrationFailed(SMAppService.Status)
 
     var errorDescription: String? {
         switch self {
-        case .authorizationFailed(let s): return "Authorization failed (OSStatus \(s))"
-        case .blessFailed:                return "SMJobBless failed — check signing and Info.plist"
+        case .requiresApproval:
+            return "Approve ChloroFrame in System Settings > General > Login Items & Extensions, then try again."
+        case .registrationFailed(let status):
+            return "Helper registration failed (status \(status.rawValue))."
         }
     }
 }

--- a/ChloroFrame/App/ChloroFrameApp.swift
+++ b/ChloroFrame/App/ChloroFrameApp.swift
@@ -32,7 +32,10 @@ struct ChloroFrameApp: App {
 class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.appearance = NSAppearance(named: .darkAqua)
-        UserDefaults.standard.register(defaults: ["suppressAWDLDuringStream": true])
+        UserDefaults.standard.register(defaults: [
+            "suppressAWDLDuringStream": true,
+            "suppressWiFiScansDuringStream": true,
+        ])
         NetworkMonitor.shared.start()
         // Defer sizing to the next run loop tick so SwiftUI's initial layout
         // pass completes first — calling setContentSize mid-layout causes the

--- a/ChloroFrame/App/Logging.swift
+++ b/ChloroFrame/App/Logging.swift
@@ -1,0 +1,41 @@
+//
+//  Logging.swift
+//  ChloroFrame
+//
+//  All diagnostic logging is intentionally no-op'd.
+//
+//  Synchronous stdout (print) can block on the console pipe with a debugger
+//  attached, os.Logger and file writes add per-call overhead, and several log
+//  sites sit on latency-critical threads (receive / decode / render / audio).
+//  Collectively they caused the microstutter we kept chasing, so every sink is
+//  neutralised:
+//
+//    • print(...)        → shadowed by the no-op below (module-wide)
+//    • os.Logger alog/rlog → replaced with NoopLog
+//    • StreamLog / SessionLog / AppLogger → no-op bodies
+//
+//  If you genuinely need a line out (e.g. a one-shot post-stream diagnostic that
+//  never runs on the hot path), call `Swift.print(...)` explicitly to bypass the
+//  shadow.
+//
+
+import Foundation
+
+// MARK: - Module-wide no-op `print`
+
+// A top-level `print` shadows `Swift.print` for all unqualified calls in this
+// module, so existing print(...) sites compile unchanged and emit nothing.
+@inline(__always)
+func print(_ items: Any..., separator: String = " ", terminator: String = "\n") {}
+
+// MARK: - No-op stand-in for os.Logger
+
+// Drop-in for the handful of `Logger` instances (alog/rlog). The @autoclosure
+// means the interpolated string is never even built.
+struct NoopLog {
+    @inline(__always) func info(_ message: @autoclosure () -> String)    {}
+    @inline(__always) func notice(_ message: @autoclosure () -> String)  {}
+    @inline(__always) func debug(_ message: @autoclosure () -> String)   {}
+    @inline(__always) func warning(_ message: @autoclosure () -> String) {}
+    @inline(__always) func error(_ message: @autoclosure () -> String)   {}
+}

--- a/ChloroFrame/App/SessionLog.swift
+++ b/ChloroFrame/App/SessionLog.swift
@@ -16,68 +16,17 @@
 //  is low-frequency (1 Hz) and always on while a stream is active.
 
 import Foundation
-import os
 
+/// Disk session log, intentionally no-op'd. Even the old async/off-thread file
+/// writes are gone — the API is kept so call sites compile unchanged, but no I/O
+/// happens. (See Logging.swift.)
 final class SessionLog {
 
     static let shared = SessionLog()
+    private init() {}
 
-    private let queue  = DispatchQueue(label: "chloroframe.sessionlog", qos: .utility)
-    private let url:    URL
-    private var handle: FileHandle?
-    private var startInstant: Date = .now
-
-    private init() {
-        // Resolve <projectRoot>/logs/session.log from this source file's location, so the
-        // log lands in the repo on whatever machine built it. Dev diagnostic only; the
-        // app is not sandboxed, so writing into the project tree is permitted.
-        //   #filePath = <projectRoot>/ChloroFrame/App/SessionLog.swift
-        let projectRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()   // App
-            .deletingLastPathComponent()   // ChloroFrame
-            .deletingLastPathComponent()   // <projectRoot>
-        url = projectRoot.appendingPathComponent("logs/session.log")
-    }
-
-    /// Resolved absolute path of the session log (for surfacing to the user).
-    var path: String { url.path }
-
-    /// Truncate any previous log, write the header, and open the file for appending.
-    /// Call once when a stream starts.
-    func begin(header: String) {
-        queue.async { [self] in
-            startInstant = .now
-            let dir = url.deletingLastPathComponent()
-            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            FileManager.default.createFile(atPath: url.path, contents: nil)
-            handle = try? FileHandle(forWritingTo: url)
-            writeNow(header)
-            Logger(subsystem: "com.chloroframe", category: "session")
-                .info("session log → \(self.url.path, privacy: .public)")
-        }
-    }
-
-    /// Append one line (newline added, prefixed with elapsed session time). Safe from any
-    /// thread — the string is captured and the write deferred to the utility queue.
-    /// Intended for low-frequency callers (1 Hz stats); not for hot-path use.
-    func line(_ s: String) {
-        let t = Date.now.timeIntervalSince(startInstant)
-        queue.async { [self] in writeNow(String(format: "[t+%6.1fs] ", t) + s) }
-    }
-
-    /// Flush and close. Call when the stream stops.
-    func end() {
-        queue.async { [self] in
-            writeNow("[session ended]")
-            try? handle?.close()
-            handle = nil
-        }
-    }
-
-    // MARK: - queue-confined
-
-    private func writeNow(_ s: String) {
-        guard let handle, let data = (s + "\n").data(using: .utf8) else { return }
-        try? handle.write(contentsOf: data)
-    }
+    var path: String { "" }
+    func begin(header: String) {}
+    func line(_ s: String) {}
+    func end() {}
 }

--- a/ChloroFrame/App/StreamLog.swift
+++ b/ChloroFrame/App/StreamLog.swift
@@ -19,15 +19,10 @@ import Foundation
 
 enum StreamLog {
 
-    /// Read once at first use; relaunch to change.
-    static let verbose = UserDefaults.standard.bool(forKey: "verboseStreamLogs")
-
-    private static let queue = DispatchQueue(label: "chloroframe.streamlog", qos: .utility)
+    /// Hard-disabled: keeps the external `if StreamLog.verbose` guard sites dead so
+    /// their gated blocks never build strings or log. (See Logging.swift.)
+    static let verbose = false
 
     @inline(__always)
-    static func log(_ line: @autoclosure () -> String) {
-        guard verbose else { return }
-        let s = line()
-        queue.async { print(s) }
-    }
+    static func log(_ line: @autoclosure () -> String) {}
 }

--- a/ChloroFrame/Audio/AudioEngine.swift
+++ b/ChloroFrame/Audio/AudioEngine.swift
@@ -23,9 +23,8 @@
 
 import Foundation
 import AVFoundation
-import os
 
-private let alog = Logger(subsystem: "com.chloroframe", category: "audio")
+private let alog = NoopLog()
 
 enum AudioEngineState {
     case stopped, priming, running
@@ -61,6 +60,9 @@ final class AudioEngine: @unchecked Sendable {
     // Max frame size passed to opus_decode_float (20 ms at 48 kHz).
     // The actual frame count decoded is what libopus returns, not this ceiling.
     private static let maxFramesPerPacket:  Int    = 960
+    // Cap on synthesized frames per gap. Beyond this the dropout is too long to
+    // conceal convincingly; we stop filling and let the buffer/servo resync.
+    private static let maxConcealFrames:    Int    = 8      // ≤ 40 ms of concealment
     // 60 ms buffered before the (pre-warmed) engine starts consuming, and the initial
     // adaptive-buffer target. Raised from 40 ms because 40 ran too tight in this CoreAudio
     // setup (playback began nearly drained on the first pull).
@@ -112,7 +114,7 @@ final class AudioEngine: @unchecked Sendable {
                                              maxLatencyFrames: initialMaxLatencyFrames)
     private let avEngine   = AVAudioEngine()
     private var sourceNode: AVAudioSourceNode?
-    private var opusDecoder: OpaquePointer? = nil
+    private var decoder: AudioPacketDecoder?
 
     // audioQueue owns all mutable state below.
     private let audioQueue = DispatchQueue(label: "chloroframe.audio", qos: .userInteractive)
@@ -132,9 +134,25 @@ final class AudioEngine: @unchecked Sendable {
     private var lastAdaptGrowNanos:   UInt64 = 0
     private var lastAdaptShrinkNanos: UInt64 = 0
 
+    // Adaptive-shrink behaviour, chosen per session from the "Prefer smoother audio" setting.
+    // Defaults below = low-latency (current behaviour); the smoother profile raises the floor
+    // and shrinks gentler so the buffer keeps more cushion (fewer underruns, more latency).
+    private var cfgFloorFrames:         Int    = AudioEngine.targetFloorFrames
+    private var cfgShrinkFrames:        Int    = AudioEngine.adaptShrinkFrames
+    private var cfgShrinkIntervalNanos: UInt64 = AudioEngine.adaptShrinkIntervalNanos
+    private var cfgMarginFrames:        Int    = AudioEngine.adaptMarginFrames
+    private var cfgPadFrames:           Int    = AudioEngine.adaptPadFrames
+
     // Diagnostics — track previous packet for delta logging (first 20 packets).
     private var diagPrevRtp:     UInt32? = nil
     private var diagPrevArrival: UInt64? = nil
+
+    // Gap concealment: last decoded RTP sequence, and a running tally for diagnostics.
+    private var lastDecodedSeq:  UInt16? = nil
+    private var concealedFrames: Int = 0
+
+    // Throttle for the 1 Hz steady-state health log (audioQueue only).
+    private var lastSummaryNanos: UInt64 = 0
 
     // Startup-timing diagnostics. The engine is pre-warmed (started at setup), so its
     // ~300 ms cold start burns off before audio matters; the render callback's snap-to-
@@ -190,10 +208,32 @@ final class AudioEngine: @unchecked Sendable {
 
     private func startOnQueue() throws {
         guard state == .stopped else { return }
-        var err: Int32 = 0
-        opusDecoder = opus_decoder_create(48000, 2, &err)
-        guard err == OPUS_OK, opusDecoder != nil else {
-            throw AudioEngineError.decoderCreationFailed(err)
+
+        // Backend chosen at stream start. Apple path falls back to libopus if the
+        // AudioConverter can't be created, so a stream never fails to get audio.
+        let useApple = UserDefaults.standard.bool(forKey: "useAppleAudioDecoder")
+        decoder = (useApple ? AppleOpusDecoder() : nil) ?? LibOpusDecoder()
+        guard decoder != nil else {
+            throw AudioEngineError.decoderCreationFailed(OPUS_ALLOC_FAIL)
+        }
+        alog.info("audio decoder backend: \(useApple ? "Apple AudioToolbox" : "libopus")")
+
+        // "Prefer smoother audio" → keep more buffer cushion and shrink it gently, so jitter
+        // bursts don't drain the buffer (fewer underruns) at the cost of a little more latency.
+        if UserDefaults.standard.bool(forKey: "preferSmootherAudio") {
+            cfgFloorFrames         = 3360             // 70 ms floor (vs 50)
+            cfgShrinkFrames        = 48               //  1 ms shrink step (vs 2)
+            cfgShrinkIntervalNanos = 2_000_000_000    // ≤1 shrink / 2 s (vs 1 s)
+            cfgMarginFrames        = 720              // 15 ms safety margin (vs 10)
+            cfgPadFrames           = 480              // 10 ms pad (vs 5)
+            alog.info("audio buffer: smoother profile (higher floor, gentler shrink)")
+        } else {
+            cfgFloorFrames         = Self.targetFloorFrames
+            cfgShrinkFrames        = Self.adaptShrinkFrames
+            cfgShrinkIntervalNanos = Self.adaptShrinkIntervalNanos
+            cfgMarginFrames        = Self.adaptMarginFrames
+            cfgPadFrames           = Self.adaptPadFrames
+            alog.info("audio buffer: low-latency profile")
         }
         setupSourceNode()
         state = .priming
@@ -221,9 +261,12 @@ final class AudioEngine: @unchecked Sendable {
 
     private func stopOnQueue() {
         avEngine.stop()
-        if let dec = opusDecoder { opus_decoder_destroy(dec); opusDecoder = nil }
+        decoder = nil
         ringBuffer.reset()
         decodeCount        = 0
+        lastDecodedSeq     = nil
+        concealedFrames    = 0
+        lastSummaryNanos   = 0
         diagPrevRtp        = nil
         diagPrevArrival    = nil
         driftAvgFrames     = Double(Self.targetPrimingFrames)
@@ -262,21 +305,49 @@ final class AudioEngine: @unchecked Sendable {
         avEngine.connect(node, to: avEngine.mainMixerNode, format: pcmFormat)
     }
 
+    /// Reconstruct the `missing` packets immediately before `packet` and write them to the
+    /// ring in order: PLC for the older frames, FEC (carried in `packet`) for the most recent.
+    /// Must run before the normal decode of `packet` so the Opus decoder state stays continuous.
+    private func concealGap(missing: Int, using packet: NetworkAudioPacket, decoder: AudioPacketDecoder) {
+        let frameSize = packet.payload.withUnsafeBytes { decoder.frameCount(of: $0) }
+        guard frameSize > 0, frameSize <= Self.maxFramesPerPacket else { return }
+
+        let conceal = min(missing, Self.maxConcealFrames)
+        withUnsafeTemporaryAllocation(of: Float.self, capacity: Self.maxFramesPerPacket * 2) { buf in
+            // Older lost frames have no reachable FEC → model concealment (deep PLC in 1.6.1).
+            for _ in 0 ..< (conceal - 1) {
+                let n = decoder.decodePLC(frameCount: frameSize, into: buf.baseAddress!)
+                if n > 0 { _ = ringBuffer.write(buf.baseAddress!, frameCount: n) }
+            }
+            // Most recent lost frame: reconstruct from this packet's in-band FEC.
+            let n = packet.payload.withUnsafeBytes {
+                decoder.decodeFEC(from: $0, frameCount: frameSize, into: buf.baseAddress!)
+            }
+            if n > 0 { _ = ringBuffer.write(buf.baseAddress!, frameCount: n) }
+        }
+
+        concealedFrames += conceal
+        if concealedFrames <= 200 {
+            alog.info("conceal: gap of \(missing) before seq=\(packet.sequenceNumber) → filled \(conceal) frame(s) (FEC+PLC), total=\(self.concealedFrames)")
+        }
+    }
+
     private func decodeAndWrite(packet: NetworkAudioPacket) {
-        guard let dec = opusDecoder else { return }
+        guard let decoder else { return }
+
+        // Fill any gap before this packet (libopus only): the most recent lost frame
+        // is reconstructed from THIS packet's in-band FEC, older ones via PLC. Keeps
+        // the timeline continuous so a jitter/loss spike doesn't drain the buffer.
+        if decoder.supportsConcealment, let last = lastDecodedSeq {
+            let missing = Int(packet.sequenceNumber &- last) - 1   // UInt16 wrap-safe
+            if missing > 0 { concealGap(missing: missing, using: packet, decoder: decoder) }
+        }
+        lastDecodedSeq = packet.sequenceNumber
 
         // Interleaved stereo float32: max 20 ms × 2 channels = 1920 floats.
         withUnsafeTemporaryAllocation(of: Float.self, capacity: Self.maxFramesPerPacket * 2) { pcmBuf in
-            let framesDecoded: Int32 = packet.payload.withUnsafeBytes { raw in
-                guard let ptr = raw.baseAddress else { return OPUS_INVALID_PACKET }
-                return opus_decode_float(
-                    dec,
-                    ptr.assumingMemoryBound(to: UInt8.self),
-                    Int32(raw.count),
-                    pcmBuf.baseAddress!,
-                    Int32(Self.maxFramesPerPacket),
-                    0  // decode_fec = 0: normal decode (not FEC concealment)
-                )
+            let framesDecoded: Int = packet.payload.withUnsafeBytes { raw in
+                decoder.decode(raw, into: pcmBuf.baseAddress!, capacityFrames: Self.maxFramesPerPacket)
             }
 
             decodeCount += 1
@@ -303,9 +374,18 @@ final class AudioEngine: @unchecked Sendable {
 
             guard framesDecoded > 0 else { return }
             let frames = Int(framesDecoded)
+            var insertDuplicate = false   // drift servo: too-empty → append a faded copy below
 
             if state == .running {
                 let now = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+
+                // 1 Hz health snapshot. Watch which counter ticks when a crackle is heard:
+                // under/over = ring under/overruns, clamp = samples shed by the latency clamp,
+                // dDrop/dIns = drift-servo hard packet drop/duplicate, conc = concealed frames.
+                if now &- lastSummaryNanos >= 1_000_000_000 {
+                    lastSummaryNanos = now
+                    alog.info("AUDIO 1s: under=\(self.ringBuffer.underrunCount) over=\(self.ringBuffer.overrunCount) clamp=\(self.ringBuffer.latencyClampFrames) dDrop=\(self.driftDrops) dIns=\(self.driftInserts) conc=\(self.concealedFrames) ring=\(self.ringBuffer.availableFrames) target=\(Int(self.adaptiveTargetFrames))")
+                }
 
                 // Track the windowed low-water mark of actual occupancy: snap down to any new
                 // dip, relax up slowly so old dips age out of the window. This gives the
@@ -331,13 +411,13 @@ final class AudioEngine: @unchecked Sendable {
                         lastAdaptGrowNanos = now
                         applyAdaptiveClamp()
                     }
-                } else if now &- lastAdaptShrinkNanos >= Self.adaptShrinkIntervalNanos {
+                } else if now &- lastAdaptShrinkNanos >= cfgShrinkIntervalNanos {
                     lastAdaptShrinkNanos = now
                     let drawdown  = max(0, adaptiveTargetFrames - lowWaterFrames)   // dip depth
-                    let needed    = drawdown + Double(Self.adaptMarginFrames)
-                    let floorT    = max(needed + Double(Self.adaptPadFrames), Double(Self.targetFloorFrames))
+                    let needed    = drawdown + Double(cfgMarginFrames)
+                    let floorT    = max(needed + Double(cfgPadFrames), Double(cfgFloorFrames))
                     if adaptiveTargetFrames > floorT {
-                        adaptiveTargetFrames = max(floorT, adaptiveTargetFrames - Double(Self.adaptShrinkFrames))
+                        adaptiveTargetFrames = max(floorT, adaptiveTargetFrames - Double(cfgShrinkFrames))
                         applyAdaptiveClamp()
                     }
                 }
@@ -350,16 +430,19 @@ final class AudioEngine: @unchecked Sendable {
                     let target = adaptiveTargetFrames
                     let band   = Double(Self.driftBandFrames)
                     if driftAvgFrames > target + band {
-                        // Too full → drop this (freshest) packet to shed ~5 ms of latency.
-                        // It was already decoded, so the Opus decoder state stays correct.
+                        // Too full → shed ~5 ms of latency. Instead of hard-dropping this packet
+                        // (an abrupt splice = click), we still write it below and ask the reader
+                        // to shed an equivalent amount via a crossfaded skip. Same latency result,
+                        // click-free. Decoder state stays correct (the packet is decoded + written).
+                        ringBuffer.requestShed(frames: frames)
                         driftDrops += 1
                         driftLastCorrection = now
                         driftAvgFrames -= Double(frames)
-                        return
                     } else if driftAvgFrames < target - band {
-                        // Too empty → duplicate this packet to add ~5 ms of cushion.
-                        // TODO: use an Opus PLC frame instead of a duplicate once PLC lands.
-                        ringBuffer.write(pcmBuf.baseAddress!, frameCount: frames)
+                        // Too empty → add ~5 ms of cushion by appending a copy of this packet
+                        // AFTER the normal write, crossfaded onto the stream so the duplicate
+                        // seam doesn't click (see below).
+                        insertDuplicate = true
                         driftInserts += 1
                         driftLastCorrection = now
                         driftAvgFrames += Double(frames)
@@ -368,6 +451,11 @@ final class AudioEngine: @unchecked Sendable {
             }
 
             ringBuffer.write(pcmBuf.baseAddress!, frameCount: frames)
+            if insertDuplicate {
+                // Append a faded copy: its head crossfades from the packet's last sample so the
+                // duplicate splice is click-free; its tail meets the next real packet normally.
+                ringBuffer.write(pcmBuf.baseAddress!, frameCount: frames, fadeInFrames: 64)
+            }
 
             // Priming → running: the pre-warmed render callback has pulled its first real
             // sample (firstReadNanos set), which means it primed and snapped to target. Flip
@@ -383,7 +471,7 @@ final class AudioEngine: @unchecked Sendable {
                     "AUDIO-START playing: ring=%.0fms dropped=%.0fms overruns=%ld  "
                     + "(pre-warm→first audio %.0fms)",
                     bufMs, dropMs, ringBuffer.overrunCount, warmMs))
-                alog.info("engine running — \(bufMs, format: .fixed(precision: 1)) ms buffered")
+                alog.info("engine running — \(bufMs) ms buffered")
             }
         }
     }

--- a/ChloroFrame/Audio/AudioPacketDecoder.swift
+++ b/ChloroFrame/Audio/AudioPacketDecoder.swift
@@ -1,0 +1,238 @@
+//
+//  AudioPacketDecoder.swift
+//  ChloroFrame
+//
+//  Pluggable Opus → PCM decoders behind a single protocol so the engine can swap
+//  backends at stream start:
+//
+//    • LibOpusDecoder  — the vendored libopus (opus_decode_float). Reference path.
+//    • AppleOpusDecoder — macOS's built-in Opus decoder via AudioToolbox's
+//      AudioConverter. 100% Apple frameworks, no third-party code. macOS ships an
+//      Opus decode component (kAudioFormatOpus is in kAudioFormatProperty_DecodeFormatIDs),
+//      so this is a thin wrapper, not a re-implementation of the codec.
+//
+//  Both produce interleaved stereo Float32 at 48 kHz into the caller's buffer and
+//  return the per-channel frame count (<= 0 on failure), matching what the engine's
+//  ring buffer expects.
+//
+
+import Foundation
+import AudioToolbox
+import CoreAudioTypes
+
+protocol AudioPacketDecoder: AnyObject {
+    /// Decode one compressed packet into interleaved stereo Float32 (48 kHz).
+    /// `out` has room for `capacityFrames * 2` floats. Returns frames decoded
+    /// per channel, or <= 0 on error.
+    func decode(_ payload: UnsafeRawBufferPointer,
+                into out: UnsafeMutablePointer<Float>,
+                capacityFrames: Int) -> Int
+
+    // MARK: Concealment (loss/jitter resilience)
+
+    /// True if this backend can reconstruct/conceal missing packets (FEC + PLC).
+    var supportsConcealment: Bool { get }
+
+    /// Frames-per-channel this packet decodes to, used to size FEC/PLC output. <= 0 if unknown.
+    func frameCount(of payload: UnsafeRawBufferPointer) -> Int
+
+    /// Reconstruct the *previous* lost frame from `nextPayload`'s in-band FEC (Opus LBRR).
+    /// Falls back to model concealment if the packet carries no FEC. Returns frames, <= 0 on failure.
+    func decodeFEC(from nextPayload: UnsafeRawBufferPointer,
+                   frameCount: Int, into out: UnsafeMutablePointer<Float>) -> Int
+
+    /// Generate one concealment frame from decoder history (deep PLC in libopus 1.6.1).
+    func decodePLC(frameCount: Int, into out: UnsafeMutablePointer<Float>) -> Int
+}
+
+// Backends that can't conceal (e.g. AudioToolbox) inherit these no-ops.
+extension AudioPacketDecoder {
+    var supportsConcealment: Bool { false }
+    func frameCount(of payload: UnsafeRawBufferPointer) -> Int { -1 }
+    func decodeFEC(from nextPayload: UnsafeRawBufferPointer,
+                   frameCount: Int, into out: UnsafeMutablePointer<Float>) -> Int { -1 }
+    func decodePLC(frameCount: Int, into out: UnsafeMutablePointer<Float>) -> Int { -1 }
+}
+
+// MARK: - libopus
+
+final class LibOpusDecoder: AudioPacketDecoder {
+
+    private var dec: OpaquePointer?
+
+    init?(sampleRate: Int32 = 48_000, channels: Int32 = 2) {
+        var err: Int32 = 0
+        dec = opus_decoder_create(sampleRate, channels, &err)
+        guard err == OPUS_OK, dec != nil else { return nil }
+    }
+
+    deinit { if let dec { opus_decoder_destroy(dec) } }
+
+    func decode(_ payload: UnsafeRawBufferPointer,
+                into out: UnsafeMutablePointer<Float>,
+                capacityFrames: Int) -> Int {
+        guard let dec, let base = payload.baseAddress else { return -1 }
+        return Int(opus_decode_float(
+            dec,
+            base.assumingMemoryBound(to: UInt8.self),
+            Int32(payload.count),
+            out,
+            Int32(capacityFrames),
+            0   // decode_fec = 0: normal decode
+        ))
+    }
+
+    var supportsConcealment: Bool { true }
+
+    func frameCount(of payload: UnsafeRawBufferPointer) -> Int {
+        guard let base = payload.baseAddress else { return -1 }
+        return Int(opus_packet_get_nb_samples(
+            base.assumingMemoryBound(to: UInt8.self), Int32(payload.count), 48_000))
+    }
+
+    func decodeFEC(from nextPayload: UnsafeRawBufferPointer,
+                   frameCount: Int, into out: UnsafeMutablePointer<Float>) -> Int {
+        guard let dec, let base = nextPayload.baseAddress else { return -1 }
+        return Int(opus_decode_float(
+            dec,
+            base.assumingMemoryBound(to: UInt8.self),
+            Int32(nextPayload.count),
+            out,
+            Int32(frameCount),
+            1   // decode_fec = 1: reconstruct the previous lost frame
+        ))
+    }
+
+    func decodePLC(frameCount: Int, into out: UnsafeMutablePointer<Float>) -> Int {
+        guard let dec else { return -1 }
+        // NULL packet → Opus runs concealment (deep PLC when models are compiled in).
+        return Int(opus_decode_float(dec, nil, 0, out, Int32(frameCount), 0))
+    }
+}
+
+// MARK: - Apple AudioToolbox
+
+final class AppleOpusDecoder: AudioPacketDecoder {
+
+    // Mutable state handed to the C input callback. A class so we can pass a
+    // stable pointer through AudioConverterFillComplexBuffer's userData.
+    final class Feed {
+        var data = UnsafeRawBufferPointer(start: nil, count: 0)
+        var channels: UInt32 = 2
+        var consumed = false
+        let desc = UnsafeMutablePointer<AudioStreamPacketDescription>.allocate(capacity: 1)
+        deinit { desc.deallocate() }
+    }
+
+    private var converter: AudioConverterRef?
+    private let channels: UInt32
+    private let feed = Feed()
+
+    init?(sampleRate: Double = 48_000, channels: UInt32 = 2) {
+        self.channels = channels
+        feed.channels = channels
+
+        var src = AudioStreamBasicDescription(
+            mSampleRate: sampleRate, mFormatID: kAudioFormatOpus,
+            mFormatFlags: 0, mBytesPerPacket: 0, mFramesPerPacket: 0,
+            mBytesPerFrame: 0, mChannelsPerFrame: channels,
+            mBitsPerChannel: 0, mReserved: 0)
+
+        // Interleaved Float32 to match the ring buffer's write layout.
+        var dst = AudioStreamBasicDescription(
+            mSampleRate: sampleRate, mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 4 * channels, mFramesPerPacket: 1,
+            mBytesPerFrame: 4 * channels, mChannelsPerFrame: channels,
+            mBitsPerChannel: 32, mReserved: 0)
+
+        var conv: AudioConverterRef?
+        guard AudioConverterNew(&src, &dst, &conv) == noErr, let conv else { return nil }
+        converter = conv
+
+        // Hand the decoder an OpusHead so it knows channel count / sample rate /
+        // pre-skip. The stream is raw Opus packets (no Ogg container).
+        var cookie = Self.opusHead(channels: channels, sampleRate: UInt32(sampleRate))
+        _ = AudioConverterSetProperty(conv, kAudioConverterDecompressionMagicCookie,
+                                      UInt32(cookie.count), &cookie)
+    }
+
+    deinit { if let converter { AudioConverterDispose(converter) } }
+
+    func decode(_ payload: UnsafeRawBufferPointer,
+                into out: UnsafeMutablePointer<Float>,
+                capacityFrames: Int) -> Int {
+        guard let converter, payload.baseAddress != nil else { return -1 }
+
+        feed.data = payload
+        feed.consumed = false
+        feed.desc.pointee = AudioStreamPacketDescription(
+            mStartOffset: 0, mVariableFramesInPacket: 0,
+            mDataByteSize: UInt32(payload.count))
+
+        var ioPackets = UInt32(capacityFrames)   // PCM: 1 packet == 1 frame
+        var abl = AudioBufferList(
+            mNumberBuffers: 1,
+            mBuffers: AudioBuffer(
+                mNumberChannels: channels,
+                mDataByteSize: UInt32(capacityFrames) * channels * 4,
+                mData: UnsafeMutableRawPointer(out)))
+
+        let status = AudioConverterFillComplexBuffer(
+            converter, opusInputProc,
+            Unmanaged.passUnretained(feed).toOpaque(),
+            &ioPackets, &abl, nil)
+
+        // noErr or a benign "no more input" return both yield the frames produced.
+        guard ioPackets > 0 else { return status == noErr ? 0 : -1 }
+        return Int(ioPackets)
+    }
+
+    /// 19-byte OpusHead identification header (RFC 7845 §5.1), used as the
+    /// AudioConverter decompression magic cookie.
+    private static func opusHead(channels: UInt32, sampleRate: UInt32) -> [UInt8] {
+        var c = Array("OpusHead".utf8)        // 8 bytes magic
+        c.append(1)                           // version
+        c.append(UInt8(channels))             // channel count
+        c.append(contentsOf: [0x00, 0x00])    // pre-skip (LE) = 0, continuous stream
+        c.append(contentsOf: [UInt8(sampleRate & 0xff),
+                              UInt8((sampleRate >> 8) & 0xff),
+                              UInt8((sampleRate >> 16) & 0xff),
+                              UInt8((sampleRate >> 24) & 0xff)])  // input sample rate (LE)
+        c.append(contentsOf: [0x00, 0x00])    // output gain (LE)
+        c.append(0)                           // channel mapping family 0 (mono/stereo)
+        return c
+    }
+}
+
+// Returned by the input proc to mean "no more data for now". Must be NON-zero:
+// returning noErr with 0 packets signals end-of-stream, which drops the converter
+// into a terminal state so it never decodes another packet. A non-zero status
+// leaves it alive across packets; decode() treats any ioPackets > 0 as success.
+private let kNoMoreOpusData: OSStatus = 1
+
+// C input callback: vends the single pending Opus packet once. On the converter's
+// follow-up call (it always asks again) we report "no more data" without EOF.
+private func opusInputProc(
+    _ converter: AudioConverterRef,
+    _ ioNumberDataPackets: UnsafeMutablePointer<UInt32>,
+    _ ioData: UnsafeMutablePointer<AudioBufferList>,
+    _ outPacketDescription: UnsafeMutablePointer<UnsafeMutablePointer<AudioStreamPacketDescription>?>?,
+    _ userData: UnsafeMutableRawPointer?
+) -> OSStatus {
+    let feed = Unmanaged<AppleOpusDecoder.Feed>.fromOpaque(userData!).takeUnretainedValue()
+
+    if feed.consumed || feed.data.baseAddress == nil {
+        ioNumberDataPackets.pointee = 0
+        return kNoMoreOpusData
+    }
+    feed.consumed = true
+
+    ioNumberDataPackets.pointee = 1
+    ioData.pointee.mNumberBuffers = 1
+    ioData.pointee.mBuffers.mNumberChannels = feed.channels
+    ioData.pointee.mBuffers.mDataByteSize = UInt32(feed.data.count)
+    ioData.pointee.mBuffers.mData = UnsafeMutableRawPointer(mutating: feed.data.baseAddress)
+    outPacketDescription?.pointee = feed.desc
+    return noErr
+}

--- a/ChloroFrame/Audio/AudioRingBuffer.swift
+++ b/ChloroFrame/Audio/AudioRingBuffer.swift
@@ -56,6 +56,15 @@ final class AudioRingBuffer: @unchecked Sendable {
     // when a burst pushed occupancy past maxLatencyFrames). Sole writer: the render callback.
     private let _latencyClampFrames = Atomic<Int>(0)
 
+    // Latency the drift servo (audioQueue) asks the reader to shed. The render callback drains
+    // it on its next pull and applies it as a crossfaded skip — same click-free path as the
+    // latency clamp — instead of the writer hard-dropping a whole packet.
+    private let _pendingShedFrames = Atomic<Int>(0)
+
+    // Equal-power crossfade window applied at any reader-side skip (clamp or drift shed) so the
+    // splice is click-free instead of a hard jump. ~1.3 ms at 48 kHz.
+    private static let skipCrossfadeFrames: Int = 64
+
     var underrunCount:  Int    { _underruns.load(ordering: .relaxed) }
     var overrunCount:   Int    { _overruns.load(ordering: .relaxed) }
     var firstReadNanos: UInt64 { _firstReadNanos.load(ordering: .relaxed) }
@@ -106,6 +115,13 @@ final class AudioRingBuffer: @unchecked Sendable {
         _maxLatencyFrames.store(min(max(n, primingTargetFrames), capacity), ordering: .relaxed)
     }
 
+    /// Drift servo (audioQueue): ask the reader to shed `frames` of latency with a crossfade,
+    /// instead of the writer hard-dropping a packet. Accumulates until the next read().
+    func requestShed(frames: Int) {
+        guard frames > 0 else { return }
+        _pendingShedFrames.store(_pendingShedFrames.load(ordering: .relaxed) &+ frames, ordering: .relaxed)
+    }
+
     deinit { buf.deallocate() }
 
     // MARK: - Write (audioQueue only)
@@ -122,7 +138,7 @@ final class AudioRingBuffer: @unchecked Sendable {
     ///
     /// Returns the number of frames written (== `frameCount`, clamped to `capacity`).
     @discardableResult
-    func write(_ src: UnsafePointer<Float>, frameCount: Int) -> Int {
+    func write(_ src: UnsafePointer<Float>, frameCount: Int, fadeInFrames: Int = 0) -> Int {
         let wp = writePos.load(ordering: .relaxed)
         let rp = readPos.load(ordering: .acquiring)
 
@@ -134,10 +150,29 @@ final class AudioRingBuffer: @unchecked Sendable {
         if frameCount > capacity - (wp - rp) {
             _overruns.store(_overruns.load(ordering: .relaxed) &+ 1, ordering: .relaxed)
         }
+
+        // Optional fade-in from the last published sample. Used to splice a duplicated packet
+        // (drift insert) onto the stream without a click. Reads buf[wp-1] (a concurrent read
+        // with the consumer is not a data race) and writes only the unpublished [wp, wp+count).
+        let fade = min(max(fadeInFrames, 0), count)
+        var lastL: Float = 0, lastR: Float = 0
+        if fade > 0, wp > 0 {
+            let lidx = (wp - 1) & mask
+            lastL = buf[lidx * 2]
+            lastR = buf[lidx * 2 + 1]
+        }
+
         for i in 0..<count {
             let idx = (wp + i) & mask
-            buf[idx * 2]     = src[(srcOffset + i) * 2]
-            buf[idx * 2 + 1] = src[(srcOffset + i) * 2 + 1]
+            var l = src[(srcOffset + i) * 2]
+            var r = src[(srcOffset + i) * 2 + 1]
+            if i < fade {
+                let g = Float(i + 1) / Float(fade + 1)   // 0 → 1
+                l = lastL * (1 - g) + l * g
+                r = lastR * (1 - g) + r * g
+            }
+            buf[idx * 2]     = l
+            buf[idx * 2 + 1] = r
         }
         writePos.store(wp + count, ordering: .releasing)
         return count
@@ -175,18 +210,28 @@ final class AudioRingBuffer: @unchecked Sendable {
             }
         }
 
-        // Max-latency clamp: bound playback latency at maxLatencyFrames (well under the
-        // physical ring). A delivery burst that pushed occupancy past the cap gets its oldest
-        // audio skipped immediately, rather than waiting for the slow drift servo. Because the
-        // cap is < capacity, this also subsumes the physical lap case (those frames are valid).
-        // readPos stays single-writer (this callback): a forward clamp respects the
-        // reader-only-advances-readPos invariant.
+        // Reader-side skip = latency clamp + drift-servo shed, applied as ONE crossfaded jump.
+        //  - Latency clamp bounds playback latency at maxLatencyFrames (a delivery burst gets its
+        //    oldest audio skipped, rather than waiting for the slow drift servo).
+        //  - Drift shed is what the servo requests instead of the writer hard-dropping a packet.
+        // readPos stays single-writer (this callback), so advancing it here is race-free; the
+        // crossfade below makes the splice click-free instead of a hard jump.
+        let entryRp = rp
+        var skip = 0
         let maxLat = _maxLatencyFrames.load(ordering: .relaxed)
         if wp - rp > maxLat {
-            _latencyClampFrames.store(_latencyClampFrames.load(ordering: .relaxed) &+ ((wp - rp) - maxLat),
-                                      ordering: .relaxed)
-            rp = wp - maxLat
+            let clampSkip = (wp - rp) - maxLat
+            _latencyClampFrames.store(_latencyClampFrames.load(ordering: .relaxed) &+ clampSkip, ordering: .relaxed)
+            skip += clampSkip
         }
+        let shedReq = _pendingShedFrames.exchange(0, ordering: .relaxed)
+        if shedReq > 0 {
+            // Never shed so far that we starve this pull of its `frameCount` frames.
+            let room = max(0, (wp - rp) - skip - frameCount)
+            skip += min(shedReq, room)
+        }
+        rp += skip
+
         let avail = wp - rp
         let count = min(frameCount, avail)
 
@@ -203,10 +248,22 @@ final class AudioRingBuffer: @unchecked Sendable {
             concealActive = false
             recoverPos = 0
         }
+
+        // When we skipped, equal-power crossfade the first `xfade` output frames from the stale
+        // continuation (entryRp+i, continuous with the previous pull) into the kept stream (rp+i).
+        let xfade = skip > 0 ? min(Self.skipCrossfadeFrames, count) : 0
         for i in 0..<count {
             let idx = (rp + i) & mask
             var l = buf[idx * 2]
             var r = buf[idx * 2 + 1]
+            if i < xfade {
+                let theta  = (Float(i) + 0.5) / Float(xfade) * (Float.pi / 2)   // 0 → π/2
+                let gKept  = sin(theta)
+                let gStale = cos(theta)
+                let sidx = (entryRp + i) & mask
+                l = buf[sidx * 2]     * gStale + l * gKept
+                r = buf[sidx * 2 + 1] * gStale + r * gKept
+            }
             if recoverPos < Self.recoverLen {
                 let g = Float(recoverPos) / Float(Self.recoverLen)
                 l *= g
@@ -268,6 +325,7 @@ final class AudioRingBuffer: @unchecked Sendable {
         _firstReadNanos.store(0, ordering: .relaxed)
         _primeDropFrames.store(0, ordering: .relaxed)
         _latencyClampFrames.store(0, ordering: .relaxed)
+        _pendingShedFrames.store(0, ordering: .relaxed)
         concealActive = false
         concealPos = 0
         concealLoopStart = 0

--- a/ChloroFrame/Common/ChloroFrameHelperProtocol.swift
+++ b/ChloroFrame/Common/ChloroFrameHelperProtocol.swift
@@ -16,6 +16,12 @@ protocol ChloroFrameHelperProtocol {
     /// Read current awdl0 IFF_UP state without changing it.
     func getAWDLEnabled(reply: @escaping (Bool) -> Void)
 
+    /// Suspend (enabled=true) or resume (enabled=false) locationd via SIGSTOP/SIGCONT.
+    /// While suspended, locationd cannot issue its periodic Wi-Fi positioning scan —
+    /// the ~0.5s/60s off-channel radio stall that spikes streaming latency. Reversible.
+    /// reply(true) on success, reply(false) if locationd wasn't found or kill() failed.
+    func setLocationScanSuppressed(enabled: Bool, reply: @escaping (Bool) -> Void)
+
     /// No-op round-trip used to verify the connection is live.
     func ping(reply: @escaping () -> Void)
 }

--- a/ChloroFrame/Info.plist
+++ b/ChloroFrame/Info.plist
@@ -2,10 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>SMPrivilegedExecutables</key>
-	<dict>
-		<key>fullstacksandbox.com.ChloroFrame.Helper</key>
-		<string>anchor apple generic and identifier "fullstacksandbox.com.ChloroFrame.Helper" and certificate leaf[subject.OU] = "UDZPCZ26XS"</string>
-	</dict>
 </dict>
 </plist>

--- a/ChloroFrame/Network/Transport/RTPAudioReceiver.swift
+++ b/ChloroFrame/Network/Transport/RTPAudioReceiver.swift
@@ -14,9 +14,8 @@
 import Foundation
 import Network
 import Synchronization
-import os
 
-private let rlog = Logger(subsystem: "com.chloroframe", category: "audio")
+private let rlog = NoopLog()
 
 final class RTPAudioReceiver {
 

--- a/ChloroFrame/Resources/fullstacksandbox.com.ChloroFrame.Helper.plist
+++ b/ChloroFrame/Resources/fullstacksandbox.com.ChloroFrame.Helper.plist
@@ -6,9 +6,10 @@
     <key>Label</key>
     <string>fullstacksandbox.com.ChloroFrame.Helper</string>
 
-    <!-- SMJobBless installs the binary to /Library/PrivilegedHelperTools/. -->
-    <key>Program</key>
-    <string>/Library/PrivilegedHelperTools/fullstacksandbox.com.ChloroFrame.Helper</string>
+    <!-- SMAppService runs the helper in-place from inside the app bundle.
+         BundleProgram is relative to the .app bundle root. -->
+    <key>BundleProgram</key>
+    <string>Contents/Library/LaunchDaemons/fullstacksandbox.com.ChloroFrame.Helper</string>
 
     <!-- On-demand: launchd starts the helper when the Mach service is first looked up. -->
     <key>MachServices</key>

--- a/ChloroFrame/UI/SettingsView.swift
+++ b/ChloroFrame/UI/SettingsView.swift
@@ -18,6 +18,8 @@ struct SettingsView: View {
     // @AppStorage("lowLatencyMode") private var lowLatencyMode = true
     @AppStorage("enableHDR") private var enableHDR = false
     @AppStorage("useSwiftFEC") private var useSwiftFEC = false
+    @AppStorage("useAppleAudioDecoder") private var useAppleAudioDecoder = false
+    @AppStorage("preferSmootherAudio") private var preferSmootherAudio = false
     @AppStorage("suppressAWDLDuringStream") private var suppressAWDL = true
 
     @State private var awdlReady = AWDLSuppressor.shared.isHelperInstalled
@@ -44,12 +46,20 @@ struct SettingsView: View {
                     .disabled(preferredCodec != "h265")
             }
 
+            section("Audio") {
+                Toggle("Decode Opus with Apple AudioToolbox", isOn: $useAppleAudioDecoder)
+                    .help("Decode the host's Opus audio with macOS's built-in decoder (AudioConverter) instead of the bundled libopus. 100% Apple frameworks. Takes effect on the next connect.")
+
+                Toggle("Prefer smoother audio (trades latency)", isOn: $preferSmootherAudio)
+                    .help("Keep more audio buffered and shrink it gently so jitter bursts don't cause dropouts. Adds a little audio latency. Leave off for lowest latency. Takes effect on the next connect.")
+            }
+
             section("Network") {
                 Toggle("Suppress AWDL During Stream", isOn: $suppressAWDL)
                     .help("Brings awdl0 down while streaming to prevent AirDrop/Handoff from competing for WiFi airtime. Automatically restored when the stream ends.")
 
-                if suppressAWDL && !awdlReady {
-                    awdlSetupRow
+                if suppressAWDL {
+                    if awdlReady { awdlReinstallRow } else { awdlSetupRow }
                 }
 
                 Toggle("Use Swift FEC", isOn: $useSwiftFEC)
@@ -108,6 +118,32 @@ struct SettingsView: View {
                 awdlSetupError = nil
                 do {
                     try AWDLSuppressor.shared.installHelper()
+                    awdlReady = AWDLSuppressor.shared.isHelperInstalled
+                } catch {
+                    awdlSetupError = error.localizedDescription
+                }
+            }
+            .font(.caption)
+            .buttonStyle(.link)
+        }
+    }
+
+    // Shown when the helper reports installed. A Debug rebuild silently staleness the
+    // registered daemon (status stays .enabled but it won't launch), so offer a re-register.
+    private var awdlReinstallRow: some View {
+        HStack(spacing: 6) {
+            if let err = awdlSetupError {
+                Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange).font(.caption)
+                Text(err).font(.caption).foregroundStyle(.red)
+            } else {
+                Image(systemName: "checkmark.circle.fill").foregroundStyle(.green).font(.caption)
+                Text("Helper installed. If AWDL stays active, re-register.").font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Re-register…") {
+                awdlSetupError = nil
+                do {
+                    try AWDLSuppressor.shared.installHelper(force: true)
                     awdlReady = AWDLSuppressor.shared.isHelperInstalled
                 } catch {
                     awdlSetupError = error.localizedDescription

--- a/ChloroFrameHelper/AWDLService.swift
+++ b/ChloroFrameHelper/AWDLService.swift
@@ -24,9 +24,19 @@ final class AWDLService: NSObject, ChloroFrameHelperProtocol {
         set { stateLock.lock(); _suppressed = newValue; stateLock.unlock() }
     }
 
+    // Tracks whether WE suspended locationd, so restore only resumes what we paused.
+    private var _locSuppressed = false
+    private var locSuppressed: Bool {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _locSuppressed }
+        set { stateLock.lock(); _locSuppressed = newValue; stateLock.unlock() }
+    }
+
     override init() {
         super.init()
         startRouteMonitor()
+        // Defensive: if a previous helper instance died while locationd was
+        // suspended, un-stick it now. SIGCONT on a running process is a no-op.
+        _ = setLocationdSuspended(false)
     }
 
     // MARK: - ChloroFrameHelperProtocol
@@ -41,17 +51,31 @@ final class AWDLService: NSObject, ChloroFrameHelperProtocol {
         reply(ioctl_isUp())
     }
 
+    func setLocationScanSuppressed(enabled: Bool, reply: @escaping (Bool) -> Void) {
+        // enabled == true  → suspend locationd (SIGSTOP), stopping its Wi-Fi scans.
+        // enabled == false → resume locationd (SIGCONT).
+        let ok = setLocationdSuspended(enabled)
+        if ok { locSuppressed = enabled }
+        reply(ok)
+    }
+
     func ping(reply: @escaping () -> Void) { reply() }
 
     // MARK: - Guaranteed restore
 
     /// Called from the XPC connection's invalidationHandler and from SIGTERM.
-    /// Safe to call multiple times — suppressed flag prevents redundant ioctl.
+    /// Safe to call multiple times — the flags prevent redundant syscalls.
     func restoreIfNeeded() {
-        guard suppressed else { return }
-        NSLog("[ChloroHelper] restoring awdl0")
-        _ = ioctl_setInterface(up: true)
-        suppressed = false
+        if suppressed {
+            NSLog("[ChloroHelper] restoring awdl0")
+            _ = ioctl_setInterface(up: true)
+            suppressed = false
+        }
+        if locSuppressed {
+            NSLog("[ChloroHelper] resuming locationd")
+            _ = setLocationdSuspended(false)
+            locSuppressed = false
+        }
     }
 
     // MARK: - ioctl
@@ -106,6 +130,43 @@ final class AWDLService: NSObject, ChloroFrameHelperProtocol {
                 _ = strncpy($0, name, Int(IFNAMSIZ) - 1)
             }
         }
+    }
+
+    // MARK: - locationd suspend / resume
+
+    /// Sends SIGSTOP (suspend) or SIGCONT (resume) to locationd. Runs as root so
+    /// kill() succeeds; SIP protects locationd from debugging, not from signals.
+    private func setLocationdSuspended(_ suspend: Bool) -> Bool {
+        guard let pid = locationdPID() else {
+            NSLog("[ChloroHelper] locationd not found")
+            return false
+        }
+        let sig = suspend ? SIGSTOP : SIGCONT
+        if kill(pid, sig) == 0 {
+            NSLog("[ChloroHelper] locationd \(suspend ? "SIGSTOP" : "SIGCONT") pid \(pid) ✓")
+            return true
+        }
+        NSLog("[ChloroHelper] kill(\(pid), \(suspend ? "STOP" : "CONT")) failed errno=\(errno)")
+        return false
+    }
+
+    private func locationdPID() -> pid_t? {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        proc.arguments = ["-x", "locationd"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        do { try proc.run() } catch {
+            NSLog("[ChloroHelper] pgrep launch failed: \(error)")
+            return nil
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        guard let first = String(data: data, encoding: .utf8)?
+                .split(separator: "\n").first,
+              let pid = pid_t(first.trimmingCharacters(in: .whitespaces))
+        else { return nil }
+        return pid
     }
 
     // MARK: - Route-socket re-suppression monitor

--- a/README.md
+++ b/README.md
@@ -91,19 +91,25 @@ Implemented, but still alpha:
   HDR.
 - Metal rendering with NV12/P010 texture paths and display-link frame pacing.
 - RTP video assembly with FEC recovery.
-- Opus audio decode through vendored libopus and CoreAudio pull playback, with an
-  adaptive jitter buffer, clock-drift correction, and waveform-repeat underrun
-  concealment.
+- Opus audio decode (vendored libopus by default, or macOS's built-in AudioToolbox
+  decoder as an opt-in, 100%-Apple path) through CoreAudio pull playback, with an
+  adaptive jitter buffer, clock-drift correction, crossfaded (click-free) buffer
+  corrections, waveform-repeat underrun concealment, and Opus FEC/PLC gap concealment.
+- Optional Wi-Fi airtime suppression while streaming via a privileged helper: brings
+  `awdl0` down and reversibly suspends locationd's periodic positioning scan (both
+  restored on stop), to reduce the periodic Wi-Fi stalls that cause audio dropouts.
 - Keyboard and mouse input over the Apollo control channel, with custom remapping of
   the fn/control/option/command modifier keys, an fn-layer latch, and a reserved
   ⌃⌥⌘ control-prefix (held: hold it to reveal an in-stream controls overlay).
 
 Known gaps:
 
-- AWDL suppression is broken and should be treated as a TODO. Do not rely on it.
+- AWDL + locationd suppression now works, but requires a correctly signed helper that
+  the user approves once in System Settings. During development, Debug rebuilds re-sign
+  the binary and can staleness the helper registration (re-register from Settings to fix).
 - Audio output-device and config-change handling (AVAudioEngine reconfiguration)
-  and LAN audio encryption are not implemented. Rare multi-second audio-only
-  delivery stalls remain, tied to the AWDL gap above.
+  and LAN audio encryption are not implemented. Some delivery jitter remains on noisy
+  Wi-Fi; it is now concealed click-free rather than eliminated.
 - Gamepad, touch, and pen input are not implemented yet.
 - Bonjour/mDNS host discovery is still a placeholder.
 
@@ -155,7 +161,8 @@ and requirement strings in:
 - `ChloroFrame/Video/`: VideoToolbox decode and Metal presentation.
 - `ChloroFrame/Audio/`: Opus decode and CoreAudio playback.
 - `ChloroFrame/Input/`: keyboard and mouse input translation.
-- `ChloroFrameHelper/`: privileged helper for future AWDL suppression work.
+- `ChloroFrameHelper/`: privileged SMAppService daemon that brings `awdl0` down and
+  suspends/resumes locationd during a stream (Wi-Fi airtime suppression).
 - `clear_pairing.sh`: local utility for clearing stored pairing credentials.
 
 ## License


### PR DESCRIPTION
…uppression

Audio-resilience pass that makes buffer corrections inaudible, adds a choice of Opus decoder, and turns the previously-broken AWDL suppression into a working AWDL + locationd Wi-Fi suppression. Full writeup in status.md §12.

Decoder
- New AudioPacketDecoder protocol with two backends behind a Settings toggle: LibOpusDecoder (vendored libopus, default) and AppleOpusDecoder (macOS AudioToolbox AudioConverter, 100% Apple, opt-in). Benchmarked on real packets: libopus ~21.6 µs/pkt vs Apple ~30.8 (925x vs 649x realtime) — libopus ~43% more CPU-efficient, both negligible.
- AppleOpusDecoder validated by an afconvert encode->decode round-trip, which caught a real bug: a per-packet AudioConverterFillComplexBuffer must signal "no more input" with a non-zero sentinel, not noErr+0, or the converter drains permanently and decodes one packet then silence. libopus stays default (efficiency + it's the only path that can FEC/PLC).

Concealment & click-free corrections
- Opus FEC + PLC gap concealment (libopus): on a sequence gap, reconstruct the most recent lost frame from the next packet's in-band FEC (decode_fec=1) and PLC the rest (deep PLC; vendored libopus is 1.6.1 with OSCE/DRED). Defensive — field loss is still ~0.
- Latency-clamp skip and drift-servo drop now share one equal-power crossfaded skip in the render callback (reader-side, race-free); drift-servo drop asks the reader to shed via requestShed instead of hard-skipping in the writer; drift-servo insert appends a fade-in duplicate. Removes the last un-crossfaded hard cut (status.md §9.3).
- "Prefer smoother audio" Settings toggle: higher buffer floor (50->70ms) and gentler shrink, fewer underruns/corrections at a little latency.

Wi-Fi suppression (was a silent no-op)
- AWDL suppression never worked: install used deprecated SMJobBless against an SMAppService bundle layout (failed with CFErrorDomainLaunchd error 2). Migrated to SMAppService.daemon (BundleProgram run-in-place), Info.plist/helper plist updated, added installHelper(force:)
  + a Settings "Re-register…" affordance for the stale-on-rebuild case.
- Helper now also suspends locationd (SIGSTOP/SIGCONT) during the stream: locationd's ~0.5s/60s positioning scan was the cause of the ~1s Wi-Fi stalls. AWDL + locationd ride the same guaranteed-restore (XPC invalidation + SIGTERM); ported from the wifiefficiencies branch (WiFiMonitor/WiFiScanProbe diagnostics deferred to the main merge).

Logging
- Per-second SessionLog disk writes + os.Logger on the decode thread + print()s were a microstutter source during streaming; all app logging is now no-op (Logging.swift module print shadow + NoopLog; StreamLog/SessionLog gutted).

Docs
- README updated (audio capabilities, AWDL/locationd status, helper description); status.md §12 and todo.md updated (both gitignored, local only).